### PR TITLE
Add support for medpro (and medcoupling) on windows

### DIFF
--- a/medpro/__init__.py
+++ b/medpro/__init__.py
@@ -1,3 +1,6 @@
+import pathlib
+import sys
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]
@@ -18,7 +21,10 @@ class MEDFilePost:
     https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/classMEDCoupling_1_1MEDFileData.html
     """
 
-    def __init__(self, file_name: str | None = None):
+    def __init__(self, file_name: str | pathlib.Path | None = None):
+        if isinstance(file_name, pathlib.Path):
+            file_name = file_name.as_posix()
+
         file_data: mc.MEDFileData
         if file_name is not None:
             file_data = mc.MEDFileData.New(file_name)
@@ -96,4 +102,7 @@ class MEDFilePost:
 
     def write(self, output_file_name: str) -> None:
         self.check()
-        self.file_data.write33(output_file_name, 2)
+        if sys.platform == "win32":
+            self.file_data.write(output_file_name, 2)
+        else:
+            self.file_data.write33(output_file_name, 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def ex_dir():
+    return pathlib.Path(__file__).parent.absolute() / "examples"

--- a/tests/test_fieldevol_3d_2d_1d.py
+++ b/tests/test_fieldevol_3d_2d_1d.py
@@ -1,9 +1,10 @@
-import medpro
 import numpy as np
 
+import medpro
 
-def test_field_evol():
-    fp = medpro.MEDFilePost("./tests/examples/box_shell_beam.rmed")
+
+def test_field_evol(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_shell_beam.rmed")
 
     assert len(fp.fieldevols_by_name) == 5
     assert "reslin__DEPL" in fp.fieldevols_by_name
@@ -16,7 +17,7 @@ def test_field_evol():
     assert "DZ" in depl_evol.components
     assert "DRX" in depl_evol.components
     assert "DRY" in depl_evol.components
-    assert "DRZ" in depl_evol.components    
+    assert "DRZ" in depl_evol.components
     assert len(depl_evol.profile_by_name) == 3
     assert len(depl_evol.timesteps) == 3
     assert len(depl_evol.field_by_timestep) == 3
@@ -30,8 +31,8 @@ def test_field_evol():
     # assert "reslin__DEPL" not in fp.fieldevols_by_name    
 
 
-def test_field():
-    fp = medpro.MEDFilePost("./tests/examples/box_shell_beam.rmed")
+def test_field(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_shell_beam.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -63,8 +64,9 @@ def test_field():
     # depl2 = depl_evol.get_field_at_timestep(1, 1)
     # assert depl2.name == "reslin2__DEPL" 
 
-def test_field_add():
-    fp = medpro.MEDFilePost("./tests/examples/box_shell_beam.rmed")
+
+def test_field_add(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_shell_beam.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -85,8 +87,9 @@ def test_field_add():
     depl -= 3.15
     assert np.array_equal(depl2.to_numpy(), (depl + 3.15).to_numpy())
 
-def test_field_add_timesteps():
-    fp = medpro.MEDFilePost("./tests/examples/box_shell_beam.rmed")
+
+def test_field_add_timesteps(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_shell_beam.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -96,8 +99,9 @@ def test_field_add_timesteps():
 
     assert np.array_equal(depl.to_numpy() + depl2.to_numpy(), (depl + depl2).to_numpy())
 
-def test_extract_group():
-    fp = medpro.MEDFilePost("./tests/examples/box_shell_beam.rmed")
+
+def test_extract_group(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_shell_beam.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -114,5 +118,5 @@ def test_extract_group():
     assert "DZ" in depl.components
     assert "DRX" in depl.components
     assert "DRY" in depl.components
-    assert "DRZ" in depl.components    
+    assert "DRZ" in depl.components
     assert depl.to_numpy().size == 15 * len(depl.components)

--- a/tests/test_fieldevol_threesteps.py
+++ b/tests/test_fieldevol_threesteps.py
@@ -2,8 +2,8 @@ import medpro
 import numpy as np
 
 
-def test_field_evol():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_deplevol.rmed")
+def test_field_evol(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_deplevol.rmed")
 
     assert len(fp.fieldevols_by_name) == 2
     assert "reslin__DEPL" in fp.fieldevols_by_name
@@ -27,8 +27,8 @@ def test_field_evol():
     # assert "reslin__DEPL" not in fp.fieldevols_by_name    
 
 
-def test_field():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_deplevol.rmed")
+def test_field(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_deplevol.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -57,8 +57,9 @@ def test_field():
     # depl2 = depl_evol.get_field_at_timestep(1, 1)
     # assert depl2.name == "reslin2__DEPL" 
 
-def test_field_add():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_deplevol.rmed")
+
+def test_field_add(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_deplevol.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -79,8 +80,9 @@ def test_field_add():
     depl -= 3.15
     assert np.array_equal(depl2.to_numpy(), (depl + 3.15).to_numpy())
 
-def test_field_add_timesteps():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_deplevol.rmed")
+
+def test_field_add_timesteps(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_deplevol.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -90,8 +92,9 @@ def test_field_add_timesteps():
 
     assert np.array_equal(depl.to_numpy() + depl2.to_numpy(), (depl + depl2).to_numpy())
 
-def test_extract_group():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_deplevol.rmed")
+
+def test_extract_group(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_deplevol.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,8 +2,8 @@ import medpro
 import numpy as np
 
 
-def test_field_evol():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+def test_field_evol(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
 
     assert len(fp.fieldevols_by_name) == 2
     assert "reslin__DEPL" in fp.fieldevols_by_name
@@ -27,8 +27,8 @@ def test_field_evol():
     # assert "reslin__DEPL" not in fp.fieldevols_by_name    
 
 
-def test_field():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+def test_field(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -57,8 +57,8 @@ def test_field():
     # depl2 = depl_evol.get_field_at_timestep(1, 1)
     # assert depl2.name == "reslin2__DEPL" 
 
-def test_field_add():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+def test_field_add(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -80,8 +80,8 @@ def test_field_add():
     assert np.array_equal(depl2.to_numpy(), (depl + 3.15).to_numpy())
 
 
-def test_extract_group():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+def test_extract_group(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]

--- a/tests/test_fields_doublenodes.py
+++ b/tests/test_fields_doublenodes.py
@@ -2,8 +2,8 @@ import medpro
 import numpy as np
 
 
-def test_field_evol_doublenodes():
-    fp = medpro.MEDFilePost("./tests/examples/box_double_nodes.rmed")
+def test_field_evol_doublenodes(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_double_nodes.rmed")
 
     assert len(fp.fieldevols_by_name) == 2
     assert "reslin__DEPL" in fp.fieldevols_by_name
@@ -27,8 +27,8 @@ def test_field_evol_doublenodes():
     # assert "reslin__DEPL" not in fp.fieldevols_by_name    
 
 
-def test_field_doublenodes():
-    fp = medpro.MEDFilePost("./tests/examples/box_double_nodes.rmed")
+def test_field_doublenodes(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_double_nodes.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -57,8 +57,8 @@ def test_field_doublenodes():
     # depl2 = depl_evol.get_field_at_timestep(1, 1)
     # assert depl2.name == "reslin2__DEPL" 
 
-def test_field_add_doublenodes():
-    fp = medpro.MEDFilePost("./tests/examples/box_double_nodes.rmed")
+def test_field_add_doublenodes(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_double_nodes.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -80,8 +80,8 @@ def test_field_add_doublenodes():
     assert np.array_equal(depl2.to_numpy(), (depl + 3.15).to_numpy())
 
 
-def test_extract_group_doublenodes():
-    fp = medpro.MEDFilePost("./tests/examples/box_double_nodes.rmed")
+def test_extract_group_doublenodes(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_double_nodes.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]

--- a/tests/test_fields_profile.py
+++ b/tests/test_fields_profile.py
@@ -2,8 +2,8 @@ import medpro
 import numpy as np
 
 
-def test_field_evol_profile():
-    fp = medpro.MEDFilePost("./tests/examples/box_profile.rmed")
+def test_field_evol_profile(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_profile.rmed")
 
     assert len(fp.fieldevols_by_name) == 2
     assert "reslin__DEPL" in fp.fieldevols_by_name
@@ -27,8 +27,8 @@ def test_field_evol_profile():
     # assert "reslin__DEPL" not in fp.fieldevols_by_name    
 
 
-def test_field_profile():
-    fp = medpro.MEDFilePost("./tests/examples/box_profile.rmed")
+def test_field_profile(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_profile.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -57,8 +57,8 @@ def test_field_profile():
     # depl2 = depl_evol.get_field_at_timestep(1, 1)
     # assert depl2.name == "reslin2__DEPL" 
 
-def test_field_add_profile():
-    fp = medpro.MEDFilePost("./tests/examples/box_profile.rmed")
+def test_field_add_profile(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_profile.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]
@@ -80,8 +80,8 @@ def test_field_add_profile():
     assert np.array_equal(depl2.to_numpy(), (depl + 3.15).to_numpy())
 
 
-def test_extract_group_profile():
-    fp = medpro.MEDFilePost("./tests/examples/box_profile.rmed")
+def test_extract_group_profile(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_profile.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,8 +1,8 @@
 import medpro
 
 
-def test_mesh():
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+def test_mesh(ex_dir):
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
     assert len(fp.params_by_name) == 0
     assert len(fp.meshes_by_name) == 1
     assert "mesh" in fp.meshes_by_name

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,9 +1,12 @@
+import pathlib
+import sys
+
 import medpro
 import tempfile, os
 
-def test_read_write():
+def test_read_write(ex_dir):
 
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
     with tempfile.TemporaryDirectory() as tempdir:
         tmpfilepath = os.path.join(tempdir, "output.rmed")
         fp.write(tmpfilepath)
@@ -15,9 +18,9 @@ def test_new_write():
         fp = medpro.MEDFilePost()
         fp.write(tmpfilepath)
 
-def test_extract_group():
+def test_extract_group(ex_dir):
 
-    fp = medpro.MEDFilePost("./tests/examples/box_with_depl.rmed")
+    fp = medpro.MEDFilePost(ex_dir / "box_with_depl.rmed")
     assert "reslin__DEPL" in fp.fieldevols_by_name
 
     depl_evol = fp.fieldevols_by_name["reslin__DEPL"]


### PR DESCRIPTION
Hey @ldallolio! In connection with https://github.com/conda-forge/staged-recipes/pull/24378#discussion_r1524741177 I used medpro to validate the compiled version of `medcoupling` on windows. All tests are passing :) (meaning we're close to merging medcoupling and releasing it on conda-forge).

I only had to make a few changes to get it working on windows. 

* I made a pytest fixture for the example dir and used pathlib to ensure it would resolve the relative path more easily. 
* And I had to add a conditional so that it uses a different write method on windows.

Let me know if you have any comments?

Best Regards
Kristoffer